### PR TITLE
test: align opening comment header in architecture-diagram.html

### DIFF
--- a/testdata/golden/architecture-diagram.html
+++ b/testdata/golden/architecture-diagram.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  library-api architecture diagram
+  architecture-diagram (library-api architecture diagram)
   Proves: a public Go library caller can render a self-contained five-page
   architecture document from a local HTML template.
 -->


### PR DESCRIPTION
Aligns opening comment header in architecture-diagram.html to name the fixture, satisfying golden corpus hygiene checks.