### PR TITLE
docs(readme): ship 0.2.4 library wording and 2026-08-19 benches

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,10 @@ Install, flags, and HTTP URLs: [getting-started.md](documentation/getting-starte
 | [plans/README.md](plans/README.md) | Implementation ledger index |
 | [LICENSE](LICENSE) | MIT license |
 
-## Library (0.2.4 target)
+## Library
 
-The 0.2.4 plan replaces the wkhtml-shaped public surface with
-`Document`/`ImageDocument`. The target symbols are present in the working tree
-and the current test suite is green; the old exports remain until the hard
-break closes. The following is the target shape.
+The supported Go API is `Document` / `ImageDocument` with explicit `Content`
+sources. The pre-0.2.4 wkhtml-shaped root exports are removed.
 
 ```go
 doc := gowkhtmltopdf.Document{
@@ -91,34 +89,50 @@ doc := gowkhtmltopdf.Document{
             HTML: []byte(`<html><body><h1>Invoice</h1></body></html>`),
         },
     }},
+    PageSize: "A4",
 }
 pdfBytes, err := doc.PDF(ctx)
 ```
 
 Local files, TOC/cover fields, network policy, and the migration table:
-[documentation/library-api.md](documentation/library-api.md).
+[documentation/library-api.md](documentation/library-api.md),
 [documentation/MIGRATION-0.2.4.md](documentation/MIGRATION-0.2.4.md).
 
 ## Performance
 
-**Current snapshot (2026-08-14):** freshly built generic `gowkhtmltopdf`
-0.2.1 versus installed **wkhtmltopdf 0.12.6.1 (patched Qt)** on Linux
-amd64, 13th Gen Intel Core i7-13700HX. Same report fixture, median of
-three process runs after one warmup.
+**Current snapshot (2026-08-19):** freshly built generic `gowkhtmltopdf`
+**0.2.4** versus installed **wkhtmltopdf 0.12.6.1 (patched Qt)** on Linux
+amd64, 13th Gen Intel Core i7-13700HX. Same report fixture (20 invoice rows
+per requested page), median of three process runs after one warmup.
 
 | Pages | gowkhtmltopdf | wkhtmltopdf | Faster by |
 |------:|--------------:|------------:|----------:|
-| 2 | 16 ms | 254 ms | **16x** |
-| 10 | 30 ms | 278 ms | **9.4x** |
-| 100 | 184 ms | 530 ms | **2.9x** |
-| 500 | 1.045 s | 1.641 s | **1.6x** |
+| 2 | 17 ms | 259 ms | **15.5x** |
+| 10 | 30 ms | 276 ms | **9.2x** |
+| 100 | 184 ms | 526 ms | **2.9x** |
+| 500 | 1.042 s | 1.671 s | **1.6x** |
 
 Faster at every tested size. Peak RSS is lower through 100 pages and
-higher from 200 pages on the generic path. Full matrix, RSS, PDF sizes,
-internal-engine and public-library `go test -bench` rows, and historical snapshots:
+higher from 200 pages on the generic path.
 
-- [testdata/golden/benchmarks/README.md](testdata/golden/benchmarks/README.md)
+Same host, same fixture family against other engines (default external
+matrix: 2 / 10 / 50 / 100 pages):
+
+| Pages | vs WeasyPrint | vs Puppeteer / Chrome |
+|------:|--------------:|----------------------:|
+| 2 | **32x** | **77x** |
+| 10 | **44x** | **48x** |
+| 50 | **52x** | **17x** |
+| 100 | **57x** | **11x** |
+
+Full matrices, RSS, PDF sizes, internal-engine and public-library
+`go test -bench` rows, and historical snapshots:
+
 - [documentation/performance.md](documentation/performance.md)
+- [testdata/golden/benchmarks/README.md](testdata/golden/benchmarks/README.md)
+- [cli-compare.md](testdata/golden/benchmarks/cli-compare.md)
+- [weasyprint-compare.md](testdata/golden/benchmarks/weasyprint-compare.md)
+- [puppeteer-compare.md](testdata/golden/benchmarks/puppeteer-compare.md)
 
 Reproduce:
 

--- a/plans/PR/pr-readme-benchmarks-0.2.4.md
+++ b/plans/PR/pr-readme-benchmarks-0.2.4.md
@@ -1,0 +1,110 @@
+## Summary
+
+Refresh the root README so the Library section describes the **shipped** 0.2.4 `Document` / `ImageDocument` API (no more “0.2.4 target”), and the Performance section matches the **2026-08-19** benchmark snapshot for 0.2.4 vs wkhtmltopdf plus WeasyPrint / Puppeteer highlights.
+
+---
+
+## Motivation / context
+
+- Plans: n/a (README honesty pass after v0.2.4)
+- Issues: see **Related issues**
+
+After the tagline PR merged, the README still described the library as a “0.2.4 target” with old exports remaining, and still cited a 2026-08-14 / 0.2.1 wkhtmltopdf table. The checked-in performance docs already have the 2026-08-19 0.2.4 numbers.
+
+---
+
+## Changes
+
+### Library section
+
+- Renamed `## Library (0.2.4 target)` → `## Library`
+- Removed “plan / target symbols / old exports remain until the hard break closes” wording
+- Documented the shipped API; example includes `PageSize` and points at the migration guide
+
+### Performance section
+
+- Snapshot date **2026-08-19**, binary **0.2.4**
+- Updated wkhtmltopdf comparison rows (2 / 10 / 100 / 500) from `cli-compare.md` / `documentation/performance.md`
+- Added compact WeasyPrint and Puppeteer/Chrome speedup table
+- Linked the full comparison artifacts under `testdata/golden/benchmarks/`
+
+---
+
+## Impact
+
+| Area | Impact |
+|------|--------|
+| **Performance** | Docs only — numbers copied from existing 2026-08-19 snapshots |
+| **Memory** | None |
+| **Behavior / correctness** | None |
+| **API / CLI** | README wording only; API already shipped in 0.2.4 |
+| **Dependencies** | None |
+| **Binary size / build time** | None |
+
+---
+
+## Breaking changes / migration
+
+| Item | Migration |
+|------|-----------|
+| None | - |
+
+---
+
+## Test plan
+
+- [x] Diff README against `documentation/performance.md` and `testdata/golden/benchmarks/cli-compare.md`
+- [x] Confirm README no longer contains `Library (0.2.4 target)` or “old exports remain”
+- [ ] Visual pass of rendered README on GitHub after PR opens
+
+### Commands
+
+```sh
+# Numbers source of truth:
+sed -n '44,106p' documentation/performance.md
+sed -n '1,21p' testdata/golden/benchmarks/cli-compare.md
+```
+
+---
+
+## Screenshots / sample output
+
+README Performance now leads with:
+
+```
+Current snapshot (2026-08-19): … gowkhtmltopdf 0.2.4 versus wkhtmltopdf 0.12.6.1
+2 pages: 17 ms vs 259 ms (15.5x)
+```
+
+---
+
+## Related issues
+
+- Relates to #54 (tagline copy landed; README still needed a numbers/API honesty pass)
+
+---
+
+## PR metadata checklist (author)
+
+- [x] Self-assigned (`--assignee @me`)
+- [x] Labels applied
+- [x] Related issues filled
+- [x] Filled body under `plans/PR/pr-readme-benchmarks-0.2.4.md`
+
+---
+
+## Follow-ups (out of scope)
+
+- `documentation/getting-started.md` still has a `## Library (0.2.4 target)` heading with similar stale “hard break closes” prose — can be cleaned in a follow-up docs PR
+
+---
+
+## Reviewer checklist
+
+- [ ] Behavior matches summary and test plan
+- [ ] No unrelated changes in diff
+- [ ] Public API / CLI changes documented
+- [ ] New rules have fixture coverage when applicable
+- [ ] PR has assignee and labels
+- [ ] Related issues use correct Closes/Relates keywords
+- [ ] No secrets or generated artifacts committed


### PR DESCRIPTION
## Summary

Refresh the root README so the Library section describes the **shipped** 0.2.4 `Document` / `ImageDocument` API (no more “0.2.4 target”), and the Performance section matches the **2026-08-19** benchmark snapshot for 0.2.4 vs wkhtmltopdf plus WeasyPrint / Puppeteer highlights.

---

## Motivation / context

- Plans: n/a (README honesty pass after v0.2.4)
- Issues: see **Related issues**

After the tagline PR merged, the README still described the library as a “0.2.4 target” with old exports remaining, and still cited a 2026-08-14 / 0.2.1 wkhtmltopdf table. The checked-in performance docs already have the 2026-08-19 0.2.4 numbers.

---

## Changes

### Library section

- Renamed `## Library (0.2.4 target)` → `## Library`
- Removed “plan / target symbols / old exports remain until the hard break closes” wording
- Documented the shipped API; example includes `PageSize` and points at the migration guide

### Performance section

- Snapshot date **2026-08-19**, binary **0.2.4**
- Updated wkhtmltopdf comparison rows (2 / 10 / 100 / 500) from `cli-compare.md` / `documentation/performance.md`
- Added compact WeasyPrint and Puppeteer/Chrome speedup table
- Linked the full comparison artifacts under `testdata/golden/benchmarks/`

---

## Impact

| Area | Impact |
|------|--------|
| **Performance** | Docs only — numbers copied from existing 2026-08-19 snapshots |
| **Memory** | None |
| **Behavior / correctness** | None |
| **API / CLI** | README wording only; API already shipped in 0.2.4 |
| **Dependencies** | None |
| **Binary size / build time** | None |

---

## Breaking changes / migration

| Item | Migration |
|------|-----------|
| None | - |

---

## Test plan

- [x] Diff README against `documentation/performance.md` and `testdata/golden/benchmarks/cli-compare.md`
- [x] Confirm README no longer contains `Library (0.2.4 target)` or “old exports remain”
- [x] Visual pass of rendered README on GitHub after PR opens

### Commands

```sh
# Numbers source of truth:
sed -n '44,106p' documentation/performance.md
sed -n '1,21p' testdata/golden/benchmarks/cli-compare.md
```

---

## Screenshots / sample output

README Performance now leads with:

```
Current snapshot (2026-08-19): … gowkhtmltopdf 0.2.4 versus wkhtmltopdf 0.12.6.1
2 pages: 17 ms vs 259 ms (15.5x)
```

---

## Related issues

- Relates to #54 (tagline copy landed; README still needed a numbers/API honesty pass)

---

## PR metadata checklist (author)

- [x] Self-assigned (`--assignee @me`)
- [x] Labels applied
- [x] Related issues filled
- [x] Filled body under `plans/PR/pr-readme-benchmarks-0.2.4.md`

---

## Follow-ups (out of scope)

- `documentation/getting-started.md` still has a `## Library (0.2.4 target)` heading with similar stale “hard break closes” prose — can be cleaned in a follow-up docs PR

---

## Reviewer checklist

- [ ] Behavior matches summary and test plan
- [ ] No unrelated changes in diff
- [ ] Public API / CLI changes documented
- [ ] New rules have fixture coverage when applicable
- [ ] PR has assignee and labels
- [ ] Related issues use correct Closes/Relates keywords
- [ ] No secrets or generated artifacts committed
