### PR TITLE
fix(pypi): force platform wheel tags for ctypes-native lib

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -66,6 +66,8 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: bash scripts/build_cshared_for_wheel.sh
           CIBW_REPAIR_WHEEL_COMMAND: ""
+          # Default Windows matrix otherwise picks win32; we only ship amd64.
+          CIBW_ARCHS_WINDOWS: AMD64
         run: python -m cibuildwheel bindings/python --output-dir dist
 
       - name: Upload wheels
@@ -122,6 +124,9 @@ jobs:
   publish:
     name: publish to PyPI
     needs: check
+    # Tag pushes only. workflow_dispatch builds + checks wheels without
+    # publishing, so we can validate cibuildwheel before cutting v*.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: pypi
     # ONE-TIME OPERATOR STEP before the first tag push (Trusted Publishing):

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ __pycache__/
 bindings/python/**/__pycache__/
 
 .vscode
+# local python package build trees
+bindings/python/build/
+bindings/python/dist/

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -48,7 +48,10 @@ gowkhtmltopdf = ["libgowkhtmltopdf.*", "py.typed"]
 # inside the manylinux container via before-build; macOS/Windows override
 # CIBW_BEFORE_BUILD in publish-pypi.yml to scripts/build_cshared_for_wheel.sh.
 [tool.cibuildwheel]
-build = "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+# Wheels are tagged py3-none-<plat> (ctypes-loaded native lib, not a CPython
+# extension), so one CPython build per platform is enough for requires-python
+# >=3.8. Building cp38..cp313 would only overwrite the same tag repeatedly.
+build = "cp311-*"
 
 [tool.cibuildwheel.linux]
 # Per-job CIBW_ARCHS_LINUX in the workflow selects x86_64 or aarch64.

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,20 +1,44 @@
-"""Build shim for version stamping.
+"""Build shim: VERSION stamp + platform wheel tags.
 
 pyproject.toml carries a static version so the package builds standalone.
 When the repo-root VERSION file exists (normal in-tree and sdist-from-repo
 builds), setup.py overrides that static value so the wheel or sdist always
-matches the release stamp in VERSION. setuptools gives setup() keyword
-arguments precedence over [project] static metadata, which makes this the
-single-source-of-truth bridge required by plans/0.2.5 Phase 46.3.
+matches the release stamp in VERSION.
+
+The package ships a prebuilt c-shared library as package data and loads it
+with ctypes. That is not a Python C extension, so setuptools would emit
+py3-none-any. cibuildwheel rejects pure-Python wheels, so this shim forces
+a platform tag (py3-none-<plat>) while keeping abi=none.
 """
 
 from pathlib import Path
 
 from setuptools import setup
 
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+except ImportError:  # pragma: no cover - wheel is listed in build-system.requires
+    _bdist_wheel = None
+
+
+class bdist_wheel(_bdist_wheel):  # type: ignore[misc,valid-type]
+    def finalize_options(self):
+        super().finalize_options()
+        self.root_is_pure = False
+
+    def get_tag(self):
+        _python, _abi, plat = super().get_tag()
+        # ctypes-loaded native lib: one wheel per OS/arch, any CPython 3.x.
+        return "py3", "none", plat
+
+
 _ROOT_VERSION = Path(__file__).resolve().parent.parent.parent / "VERSION"
 
+_kwargs = {}
+if _bdist_wheel is not None:
+    _kwargs["cmdclass"] = {"bdist_wheel": bdist_wheel}
+
 if _ROOT_VERSION.is_file():
-    setup(version=_ROOT_VERSION.read_text(encoding="utf-8").strip())
-else:
-    setup()
+    _kwargs["version"] = _ROOT_VERSION.read_text(encoding="utf-8").strip()
+
+setup(**_kwargs)


### PR DESCRIPTION
## Summary
- Root cause of the latest publish-pypi failures: native lib built fine, but the wheel was still `py3-none-any`, which cibuildwheel rejects.
- Force `py3-none-<plat>` via setup.py `bdist_wheel` (`root_is_pure = False`).
- Build `cp311-*` only (enough for `requires-python >=3.8` with a `py3` tag).
- Pin `CIBW_ARCHS_WINDOWS=AMD64`.
- Publish job runs only on `v*` tags so we can dry-run with workflow_dispatch before retagging.

## Test plan
- [x] Deleted broken `v0.2.5` tag/release again
- [x] Local `pip wheel` now produces `gowkhtmltopdf-0.2.5-py3-none-linux_x86_64.whl`
- [ ] After merge: `workflow_dispatch` publish-pypi and wait for wheel jobs green
- [ ] Only then retag `v0.2.5`