### PR TITLE
fix(pypi): put ctypes native lib in platlib for auditwheel

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,4 +1,4 @@
-"""Build shim: VERSION stamp + platform wheel tags.
+"""Build shim: VERSION stamp + platform/platlib wheel tags.
 
 pyproject.toml carries a static version so the package builds standalone.
 When the repo-root VERSION file exists (normal in-tree and sdist-from-repo
@@ -6,19 +6,34 @@ builds), setup.py overrides that static value so the wheel or sdist always
 matches the release stamp in VERSION.
 
 The package ships a prebuilt c-shared library as package data and loads it
-with ctypes. That is not a Python C extension, so setuptools would emit
-py3-none-any. cibuildwheel rejects pure-Python wheels, so this shim forces
-a platform tag (py3-none-<plat>) while keeping abi=none.
+with ctypes. That is not a Python C extension, so setuptools would:
+  1. emit py3-none-any (cibuildwheel rejects pure-Python wheels)
+  2. put .so/.dylib/.dll under purelib (auditwheel rejects that)
+
+Force a platform tag (py3-none-<plat>) and a BinaryDistribution so the
+native library lands in platlib and auditwheel can repair the wheel.
 """
 
 from pathlib import Path
 
 from setuptools import setup
+from setuptools.dist import Distribution
 
 try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 except ImportError:  # pragma: no cover - wheel is listed in build-system.requires
     _bdist_wheel = None
+
+
+class BinaryDistribution(Distribution):
+    """Tell setuptools this package is platform-specific.
+
+    Without this, package-data shared libraries install into purelib and
+    auditwheel fails with "shared library in purelib folder".
+    """
+
+    def has_ext_modules(self):
+        return True
 
 
 class bdist_wheel(_bdist_wheel):  # type: ignore[misc,valid-type]
@@ -34,7 +49,9 @@ class bdist_wheel(_bdist_wheel):  # type: ignore[misc,valid-type]
 
 _ROOT_VERSION = Path(__file__).resolve().parent.parent.parent / "VERSION"
 
-_kwargs = {}
+_kwargs = {
+    "distclass": BinaryDistribution,
+}
 if _bdist_wheel is not None:
     _kwargs["cmdclass"] = {"bdist_wheel": bdist_wheel}
 


### PR DESCRIPTION
## Summary
- Latest failure: auditwheel `shared library in purelib folder` for `libgowkhtmltopdf.so`.
- Mark the distribution as binary via `BinaryDistribution.has_ext_modules` so package data lands in platlib.
- Local check: wheel is `Root-Is-Purelib: false` and `auditwheel show` no longer complains about purelib.

## Test plan
- [x] `v0.2.5` tag/release remain deleted
- [x] Local platform wheel + auditwheel show (no purelib error)
- [ ] Merge, `workflow_dispatch` publish-pypi, wait for all wheel jobs green
- [ ] Only then recreate `v0.2.5`